### PR TITLE
Resolve 'nan' side-effect with stringify function

### DIFF
--- a/target_s3_parquet/sanitizer.py
+++ b/target_s3_parquet/sanitizer.py
@@ -1,4 +1,5 @@
 from pandas import DataFrame
+import numpy as np
 import json
 from typing import List
 
@@ -48,3 +49,7 @@ def apply_json_dump_to_df(
         for attribute in valid_attributes:
             df.loc[:, attribute] = df[attribute].apply(lambda x: json.dumps(x))
     return df
+
+
+def stringify_df(df: DataFrame) -> DataFrame:
+    return df.fillna("NULL").astype(str).replace("NULL", np.nan)

--- a/target_s3_parquet/sinks.py
+++ b/target_s3_parquet/sinks.py
@@ -14,6 +14,7 @@ from target_s3_parquet.data_type_generator import (
 from target_s3_parquet.sanitizer import (
     get_specific_type_attributes,
     apply_json_dump_to_df,
+    stringify_df,
 )
 
 
@@ -73,7 +74,7 @@ class S3ParquetSink(BatchSink):
                 self.schema["properties"], "object"
             )
             df_transformed = apply_json_dump_to_df(df, attributes_names)
-            df = df_transformed.astype(str)
+            df = stringify_df(df_transformed)
 
         self.logger.debug(f"DType Definition: {dtype}")
 

--- a/target_s3_parquet/tests/test_data_transformation.py
+++ b/target_s3_parquet/tests/test_data_transformation.py
@@ -1,9 +1,12 @@
+from sqlalchemy import true
 from target_s3_parquet.sanitizer import (
     get_specific_type_attributes,
     apply_json_dump_to_df,
     get_valid_attributes,
+    stringify_df,
 )
 from pandas import DataFrame
+import numpy as np
 import json
 
 
@@ -98,3 +101,9 @@ def test_shouldnt_get_valid_attributes():
     attributes_names = ["property_name"]
     valid_attributes = get_valid_attributes(attributes_names, df)
     assert valid_attributes == []
+
+
+def test_stringify_df():
+    df = DataFrame({"a": ["1", np.nan, "3"], "b": [np.nan, "y", "z"]})
+    df_stringified = stringify_df(df)
+    assert df_stringified.isna().sum().sum() == 2, "should preset 2 na fields"


### PR DESCRIPTION
when converting the received dataframe to string the np.nan object was beeing converted to a  "nan" string. The following solution remove this side-effect.