### PR TITLE
Automatically create database if it doesn't exist

### DIFF
--- a/target_s3_parquet/sinks.py
+++ b/target_s3_parquet/sinks.py
@@ -37,6 +37,8 @@ class S3ParquetSink(BatchSink):
 
         self._glue_schema = self._get_glue_schema()
 
+        wr.catalog.create_database(self.config.get("athena_database"), exist_ok=True)
+
     def _get_glue_schema(self):
 
         catalog_params = {


### PR DESCRIPTION
With Meltano, I like to namespace each extractor to a new database to avoid conflicts (like `tap-github` and `tap-shopify` both having `users` tables) by setting the database name dynamically:

```yml
config:
  athena_database: $MELTANO_EXTRACTOR_NAMESPACE
  ```

However this means the database needs to exist before the tap can be run.

This change runs `CREATE DATABASE IF NOT EXISTS` before uploading.

Because https://github.com/meltano/sdk/issues/246 hasn't been implemented, there's not a clean place to put a setup step to run once before the whole target run. Instead this will run for each sink in the constructor, which is not ideal but it should be fine.