### PR TITLE
AWS config args not required

### DIFF
--- a/target_s3_parquet/target.py
+++ b/target_s3_parquet/target.py
@@ -17,11 +17,11 @@ class TargetS3Parquet(Target):
             description="The s3 path to the target output file",
             required=True,
         ),
-        th.Property("aws_access_key_id", th.StringType, required=True),
+        th.Property("aws_access_key_id", th.StringType, required=False),
         th.Property(
             "aws_secret_access_key",
             th.StringType,
-            required=True,
+            required=False,
         ),
         th.Property("athena_database", th.StringType, required=True),
         th.Property("add_record_metadata", th.BooleanType, default=None),


### PR DESCRIPTION
Turning required = False for the `aws_access_key_id` and `aws_secret_access_key` config options will allow auth through IAM role possible. Leaving these values black or omitting them entirely did not work :( 