### PR TITLE
use .get method with default {} for attributes["properties"]

### DIFF
--- a/target_s3_parquet/data_type_generator.py
+++ b/target_s3_parquet/data_type_generator.py
@@ -54,8 +54,10 @@ def generate_tap_schema(schema, level=0, only_string=False):
             continue
 
         if cleaned_type == "object":
+            if attributes.get("properties") is None:
+                print('type is object but no properties found for:', name)
             field_definitions[name] = build_struct_type(
-                attributes["properties"], new_level
+                attributes.get("properties", {}), new_level
             )
         elif cleaned_type == "array":
             array_type = get_valid_types(attributes["items"]["type"])

--- a/target_s3_parquet/data_type_generator.py
+++ b/target_s3_parquet/data_type_generator.py
@@ -54,8 +54,6 @@ def generate_tap_schema(schema, level=0, only_string=False):
             continue
 
         if cleaned_type == "object":
-            if attributes.get("properties") is None:
-                print('type is object but no properties found for:', name)
             field_definitions[name] = build_struct_type(
                 attributes.get("properties", {}), new_level
             )


### PR DESCRIPTION
Target was failing on below block for stripe charges where there is a field that was type = object but did not have a properties key.
```
if cleaned_type == "object":
            field_definitions[name] = build_struct_type(
                attributes["properties"], new_level
            )
```

This change resolved the failure.

Ex of failing attribute:
<img width="211" alt="image" src="https://github.com/gupy-io/target-s3-parquet/assets/59591903/7d3e3846-a1d4-4819-9bd2-3481f9ee5f6f">

Ex of other type object attribute:
<img width="198" alt="image" src="https://github.com/gupy-io/target-s3-parquet/assets/59591903/bb06e18a-4164-4d16-b10b-df3eae0a90be">
